### PR TITLE
Adding methods to multiply by scalars from the underlying field and an option to return the category before finalizing it.

### DIFF
--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -333,6 +333,14 @@ function( M )
   fi;
 end );
 
+InstallMethod( \*, [ IsMultiplicativeElement, IsQPAMatrix ],
+function( a, M )
+  if not a in BaseDomain( M ) then
+    TryNextMethod( );
+  fi;
+  return MatrixByRows( BaseDomain( M ), DimensionsMat( M ), a*RowsOfMatrix( M ) );
+end );
+
 InstallMethod( \*, "for standard vector and QPA matrix",
                [ IsStandardVector, IsQPAMatrix ],
 function( v, M )

--- a/lib/representation.gi
+++ b/lib/representation.gi
@@ -837,7 +837,7 @@ function( A, vecspace_cat )
         identity_morphism, pre_compose, addition, additive_inverse,
         kernel, kernel_emb, coker, coker_proj,
         mono_lift, epi_colift,
-        direct_sum, direct_sum_inj, direct_sum_proj;
+        direct_sum, direct_sum_inj, direct_sum_proj, to_be_finalized;
 
   Q := QuiverOfAlgebra( A );
 
@@ -1017,9 +1017,16 @@ function( A, vecspace_cat )
   end;
   AddProjectionInFactorOfDirectSumWithGivenDirectSum( cat, direct_sum_proj );
   
-  Finalize( cat );
-
+  to_be_finalized := ValueOption( "FinalizeCategory" );
+   
+  if to_be_finalized = false then
+     return cat;
+  else
+     Finalize( cat );
+  fi;
+  
   return cat;
+    
 end );
 
 

--- a/lib/representation.gi
+++ b/lib/representation.gi
@@ -1400,3 +1400,15 @@ function( R1, R2, generators, images )
     fi;
 end
   );
+
+##
+InstallMethod( InverseOp,
+    [ IsQuiverRepresentationHomomorphism ],
+function( m )
+  local maps;
+  if not IsIsomorphism( m ) then
+    Error( "The quiver representation homomorphism is not isomorphism" );
+  fi;
+  maps := List( MapsOfRepresentationHomomorphism( m ), Inverse );
+  return QuiverRepresentationHomomorphism( Range( m ), Source( m ), maps );
+end );

--- a/lib/representation.gi
+++ b/lib/representation.gi
@@ -219,6 +219,14 @@ function( e, c )
   fi;
 end );
 
+InstallMethod( \*, [ IsMultiplicativeElement, IsQuiverRepresentationHomomorphism ],
+  function( c, m )
+  local Q;
+  Q := QuiverOfRepresentation( Source( m ) );
+  return QuiverRepresentationHomomorphismNC
+  ( Source( m ), Range( m ), c*List( Vertices( Q ), v -> MapForVertex( m, v ) ) );
+end );
+
 # TODO module structure
 
 

--- a/lib/representation.gi
+++ b/lib/representation.gi
@@ -1025,6 +1025,11 @@ function( A, vecspace_cat )
   end;
   AddProjectionInFactorOfDirectSumWithGivenDirectSum( cat, direct_sum_proj );
   
+  # The object/morphism constructors check whether the input is well-defined or not.
+  # So if it has been created then it is well-defined
+  AddIsWellDefinedForObjects( cat, ReturnTrue );
+  AddIsWellDefinedForMorphisms( cat, ReturnTrue );
+
   to_be_finalized := ValueOption( "FinalizeCategory" );
    
   if to_be_finalized = false then

--- a/lib/vecspace.gi
+++ b/lib/vecspace.gi
@@ -570,6 +570,11 @@ function( m1, m2 )
   elif dim2[ 2 ] = 0 then
     return m1;
   fi;
+  
+  if dim1[ 1 ] = 0 then 
+    return MakeZeroMatrix( F, 0, dim1[ 2 ] + dim2[ 2 ] );
+  fi;
+
   rows := ListN( RowsOfMatrix( m1 ), RowsOfMatrix( m2 ), Concatenation );
   return MatrixByRows( F, rows );
 end );
@@ -595,6 +600,9 @@ function( m1, m2 )
     return m2;
   elif dim2[ 1 ] = 0 then
     return m1;
+  fi;
+  if dim1[ 2 ] = 0 then 
+    return MakeZeroMatrix( F, dim1[ 1 ] + dim2[ 1 ], 0 );
   fi;
   rows := Concatenation( RowsOfMatrix( m1 ), RowsOfMatrix( m2 ) );
   return MatrixByRows( F, rows );

--- a/lib/vecspace.gi
+++ b/lib/vecspace.gi
@@ -668,3 +668,10 @@ function( f, v )
   fi;
 end
 );
+
+##
+InstallMethod( InverseOp,
+    [ IsLinearTransformation ],
+function( m )
+  return LiftAlongMonomorphism( m, IdentityMorphism( Range( m ) ) );
+end );


### PR DESCRIPTION
1-  
`CategoryOfQuiverRepresentations( algebra );`
returns the category of quiver representations after finalizing it and
`CategoryOfQuiverRepresentations( algebra: FinalizeCategory := false );`
returns the category of quiver representations without finalizing it, which make it possible for the user 
to add extra categorical operations.

2- Two methods to multiply a quiver representation homomorphism or a QPA-matrix by a scalar from the underlying field.
3- Working a special case in stacking two QPA-matrices.
