### PR TITLE
DeclareAttribute( "IsTensorProductOfAlgebras" -> DeclareProperty

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -2,7 +2,7 @@ SetPackageInfo( rec(
 PackageName := "QPA",
 Subtitle := "Quivers and Path Algebras",
 Version := "2.0-dev",
-Date := "19/06/2018",
+Date := "28/06/2018",
 
 PackageWWWHome := "http://www.math.ntnu.no/~oyvinso/QPA/",
 ArchiveURL := Concatenation( ~.PackageWWWHome, "qpa-", ~.Version ),

--- a/lib/algebra.gd
+++ b/lib/algebra.gd
@@ -543,7 +543,7 @@ DeclareOperation( "TensorProductOfAlgebras", [ IsQuiverAlgebra, IsQuiverAlgebra 
 #! @Description
 #!  Returns <C>true</C> if the algebra <A>T</A> is a tensor product of
 #!  algebras; <C>false</C> otherwise.
-DeclareAttribute( "IsTensorProductOfAlgebras", IsQuiverAlgebra );
+DeclareProperty( "IsTensorProductOfAlgebras", IsQuiverAlgebra );
 
 DeclareAttribute( "TensorProductFactors", IsQuiverAlgebra );
 


### PR DESCRIPTION
would otherwise lead to an error in the current master branch of GAP,
while executing

DeclareAttribute( "TensorAlgebraInclusions", IsTensorProductOfAlgebras );